### PR TITLE
Context providers

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,14 +1,17 @@
-import { FunctionComponent } from "react";
+import { Context, FunctionComponent } from "react";
 import Telepath from "telepath-unpack";
 
 export default class Config {
   public views: Map<string, FunctionComponent>;
+
+  public contextProviders: Map<string, Context<unknown>>;
 
   // Telepath Doesn't support typescript yet
   public telepathRegistry: Telepath;
 
   constructor() {
     this.views = new Map();
+    this.contextProviders = new Map();
     this.telepathRegistry = new Telepath();
 
     // Add default deserializers
@@ -20,6 +23,14 @@ export default class Config {
     component: FunctionComponent<P>
   ): Config => {
     this.views.set(name, component as FunctionComponent<object>);
+    return this;
+  };
+
+  public addContextProvider = <C>(
+    name: string,
+    context: Context<C>
+  ): Config => {
+    this.contextProviders.set(name, context as Context<unknown>);
     return this;
   };
 

--- a/packages/core/src/index.tsx
+++ b/packages/core/src/index.tsx
@@ -188,7 +188,7 @@ export function App({ config, initialResponse }: AppProps): ReactElement {
               <DirtyFormScope>
                 {overlay.render(
                   <Browser
-                    views={config.views}
+                    config={config}
                     navigationController={overlay.navigationController}
                     openOverlay={() => {}}
                   />,
@@ -201,7 +201,7 @@ export function App({ config, initialResponse }: AppProps): ReactElement {
               </DirtyFormScope>
             )}
           <Browser
-            views={config.views}
+            config={config}
             navigationController={navigationController}
             openOverlay={(url, renderOverlay, options) =>
               openOverlay(url, renderOverlay, options)


### PR DESCRIPTION
This PR implements a new method for using global context providers on the frontend.

Given the following django settings:
```python
DJANGO_RENDER = {
    ...

    "CONTEXT_PROVIDERS": {
        "mycontext": "myapp.context_providers.mycontext"
    }
}
```

And the following code in ``myapp/context_providers.py``:

```python
def mycontext(request):
    return {
        "username": request.user.username,
        "email": request.user.email,
        "favourite_number": 123
    }
```

You can now register a context provider on the frontend that `django-render` will use to provide this data to components.

**Registering a context provider**

In your ``contexts.tsx``, create a React context provider with a type that matches what the Python function returns:

```tsx
import { createContext } from "react"

interface MyContextType {
    username: string;
    email: string;
    favourite_number: number;
}

export const MyContext = createContext<MyContextType>(undefined);
```

Then, in ``main.tsx`` register the context provider with `django-render`:

```tsx
import * as DjangoRender from "@django-render/core";
import { MyContext } from "./contexts";

const djangoRenderConfig = new DjangoRender.Config();
djangoRenderConfig.addContextProvider("mycontext", MyContext);

...
```

**Using the context provider in a component**

Now, Django-render will call the context provider function on every request, and pass the resulting value into the `mycontext` context so it can be used in any component:

```tsx
import { MyContext } from "./contexts";

export default function HomeView() {
  const { username } = React.useContext(MyContext);

  return (
    <>
      <h1>Hello {username}, welcome to your new Django Render app!</h1>
    </>
  );
}
```