### PR TITLE
Don't report blocked close request when close not requested

### DIFF
--- a/packages/core/src/components/Overlay.tsx
+++ b/packages/core/src/components/Overlay.tsx
@@ -40,7 +40,7 @@ export default function Overlay({
     () => ({
       overlay: true,
       closeRequested,
-      closeBlocked: dirtyFormContext.isDirty,
+      closeBlocked: closeRequested && dirtyFormContext.isDirty,
       requestClose: requestCloseCallback,
       onCloseCompleted,
     }),


### PR DESCRIPTION
The `closeBlocked` flag was being set whenever the form was made dirty, regardless of whether an overlay was requested to be closed.

Fixes #12