### PR TITLE
Refactor navigation controllers to use React state management

### DIFF
--- a/packages/core/src/components/Browser.tsx
+++ b/packages/core/src/components/Browser.tsx
@@ -25,14 +25,8 @@ function Browser({
   navigationController,
   openOverlay,
 }: BrowserProps): ReactElement {
-  const {
-    currentFrame,
-    navigate,
-    pushFrame,
-    replacePath,
-    submitForm,
-    refreshProps,
-  } = navigationController;
+  const { currentFrame, navigate, replacePath, submitForm, refreshProps } =
+    navigationController;
 
   // Push any messages from the server
   const { pushMessage } = React.useContext(MessagesContext);
@@ -62,7 +56,6 @@ function Browser({
 
         return requestUnload().then(() => navigate(url, options.pushState));
       },
-      pushFrame,
       replacePath,
       submitForm,
       openOverlay,
@@ -70,7 +63,6 @@ function Browser({
     }),
     [
       currentFrame,
-      pushFrame,
       replacePath,
       submitForm,
       openOverlay,

--- a/packages/core/src/components/Overlay.tsx
+++ b/packages/core/src/components/Overlay.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement, ReactNode } from "react";
 import Config from "../config";
 import { OverlayContext, OverlayContextType } from "../contexts";
 import { DirtyFormContext } from "../dirtyform";
-import { NavigationController } from "../navigation";
+import { NavigationController, useNavigationController } from "../navigation";
 import Browser from "./Browser";
 import { DjangoRenderResponse } from "../fetch";
 
@@ -29,8 +29,9 @@ export default function Overlay({
   onCloseCompleted,
   onServerError,
 }: OverlayProps): ReactElement {
-  const [navigationController] = React.useState(
-    () => new NavigationController(parentNavigationContoller, config.unpack)
+  const navigationController = useNavigationController(
+    parentNavigationContoller,
+    config.unpack
   );
 
   const [forceRender, setForceRender] = React.useState(0);

--- a/packages/core/src/components/Overlay.tsx
+++ b/packages/core/src/components/Overlay.tsx
@@ -70,7 +70,7 @@ export default function Overlay({
     ]
   );
 
-  if (navigationController.isLoading()) {
+  if (navigationController.isLoading) {
     // eslint-disable-next-line react/jsx-no-useless-fragment
     return <></>;
   }

--- a/packages/core/src/components/Overlay.tsx
+++ b/packages/core/src/components/Overlay.tsx
@@ -31,21 +31,10 @@ export default function Overlay({
 }: OverlayProps): ReactElement {
   const navigationController = useNavigationController(
     parentNavigationContoller,
-    config.unpack
+    config.unpack,
+    initialResponse,
+    initialPath
   );
-
-  const [forceRender, setForceRender] = React.useState(0);
-  React.useEffect(() => {
-    // Add listener to re-render the app if a navigation event occurs
-    navigationController.addNavigationListener(() => {
-      // HACK: Update some state to force a re-render
-      setForceRender(forceRender + Math.random());
-    });
-
-    // Load initial response
-    // eslint-disable-next-line no-void
-    void navigationController.handleResponse(initialResponse, initialPath);
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Add a listener to listen for when the overlay is closed by the server
   React.useEffect(() => {

--- a/packages/core/src/components/Overlay.tsx
+++ b/packages/core/src/components/Overlay.tsx
@@ -33,26 +33,12 @@ export default function Overlay({
     parentNavigationContoller,
     config.unpack,
     initialResponse,
-    initialPath
+    initialPath,
+    {
+      onOverlayClose: requestClose,
+      onServerError,
+    }
   );
-
-  // Add a listener to listen for when the overlay is closed by the server
-  React.useEffect(() => {
-    navigationController.addCloseListener(requestClose);
-
-    return () => {
-      navigationController.removeCloseListener(requestClose);
-    };
-  }, [navigationController, requestClose]);
-
-  // Add listener to raise any server errors that the overlay navigation controller encounters
-  React.useEffect(() => {
-    navigationController.addServerErrorListener(onServerError);
-
-    return () => {
-      navigationController.removeServerErrorListener(onServerError);
-    };
-  }, [navigationController, onServerError]);
 
   // If close is requested, but there is a dirty form (form without saved changes) in the overlay, block the close
   const dirtyFormContext = React.useContext(DirtyFormContext);

--- a/packages/core/src/components/Overlay.tsx
+++ b/packages/core/src/components/Overlay.tsx
@@ -4,24 +4,66 @@ import { OverlayContext, OverlayContextType } from "../contexts";
 import { DirtyFormContext } from "../dirtyform";
 import { NavigationController } from "../navigation";
 import Browser from "./Browser";
+import { DjangoRenderResponse } from "../fetch";
 
 export interface OverlayProps {
   config: Config;
-  navigationController: NavigationController;
+  initialResponse: DjangoRenderResponse;
+  initialPath: string;
+  parentNavigationContoller: NavigationController;
   render: (content: ReactNode) => ReactNode;
   requestClose: () => void;
   closeRequested: boolean;
   onCloseCompleted: () => void;
+  onServerError: (kind: "server" | "network") => void;
 }
 
 export default function Overlay({
   config,
-  navigationController,
+  initialResponse,
+  initialPath,
+  parentNavigationContoller,
   render,
   requestClose,
   closeRequested,
   onCloseCompleted,
+  onServerError,
 }: OverlayProps): ReactElement {
+  const [navigationController] = React.useState(
+    () => new NavigationController(parentNavigationContoller, config.unpack)
+  );
+
+  const [forceRender, setForceRender] = React.useState(0);
+  React.useEffect(() => {
+    // Add listener to re-render the app if a navigation event occurs
+    navigationController.addNavigationListener(() => {
+      // HACK: Update some state to force a re-render
+      setForceRender(forceRender + Math.random());
+    });
+
+    // Load initial response
+    // eslint-disable-next-line no-void
+    void navigationController.handleResponse(initialResponse, initialPath);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Add a listener to listen for when the overlay is closed by the server
+  React.useEffect(() => {
+    navigationController.addCloseListener(requestClose);
+
+    return () => {
+      navigationController.removeCloseListener(requestClose);
+    };
+  }, [navigationController, requestClose]);
+
+  // Add listener to raise any server errors that the overlay navigation controller encounters
+  React.useEffect(() => {
+    navigationController.addServerErrorListener(onServerError);
+
+    return () => {
+      navigationController.removeServerErrorListener(onServerError);
+    };
+  }, [navigationController, onServerError]);
+
   // If close is requested, but there is a dirty form (form without saved changes) in the overlay, block the close
   const dirtyFormContext = React.useContext(DirtyFormContext);
   const requestCloseCallback = React.useCallback(
@@ -51,6 +93,11 @@ export default function Overlay({
       requestCloseCallback,
     ]
   );
+
+  if (navigationController.isLoading()) {
+    // eslint-disable-next-line react/jsx-no-useless-fragment
+    return <></>;
+  }
 
   return (
     <OverlayContext.Provider value={overlayContext}>

--- a/packages/core/src/contexts.ts
+++ b/packages/core/src/contexts.ts
@@ -42,16 +42,6 @@ export interface Navigation {
   props: Record<string, unknown>;
   context: Record<string, unknown>;
   navigate: (path: string, options?: NavigateOptions) => Promise<void>;
-  pushFrame: (
-    path: string,
-    title: string,
-    view: string,
-    props: Record<string, unknown>,
-    context: Record<string, unknown>,
-    serverMessages: Message[],
-    pushState?: boolean,
-    reload?: boolean
-  ) => void;
   replacePath: (frameId: number, path: string) => void;
   submitForm: (path: string, data: FormData) => Promise<void>;
   openOverlay: (
@@ -72,10 +62,6 @@ export const NavigationContext = React.createContext<Navigation>({
     console.error("navigate() called from outside a Django Render Browser");
 
     return Promise.resolve();
-  },
-  pushFrame: () => {
-    // eslint-disable-next-line no-console
-    console.error("pushFrame() called from outside a Django Render Browser");
   },
   replacePath: () => {
     // eslint-disable-next-line no-console

--- a/packages/core/src/index.tsx
+++ b/packages/core/src/index.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement, ReactNode } from "react";
 
 import Browser from "./components/Browser";
 import { Message, DjangoRenderResponse, djangoGet } from "./fetch";
-import { Frame, NavigationController } from "./navigation";
+import { Frame, useNavigationController } from "./navigation";
 import { DirtyFormScope } from "./dirtyform";
 import Link, { BuildLinkElement, buildLinkElement } from "./components/Link";
 import Config from "./config";
@@ -16,9 +16,7 @@ export interface AppProps {
 }
 
 export function App({ config, initialResponse }: AppProps): ReactElement {
-  const [navigationController] = React.useState(
-    () => new NavigationController(null, config.unpack)
-  );
+  const navigationController = useNavigationController(null, config.unpack);
   const [overlay, setOverlay] = React.useState<{
     render(content: ReactNode): ReactNode;
     initialResponse: DjangoRenderResponse;

--- a/packages/core/src/index.tsx
+++ b/packages/core/src/index.tsx
@@ -16,7 +16,14 @@ export interface AppProps {
 }
 
 export function App({ config, initialResponse }: AppProps): ReactElement {
-  const navigationController = useNavigationController(null, config.unpack);
+  const initialPath =
+    window.location.pathname + window.location.search + window.location.hash;
+  const navigationController = useNavigationController(
+    null,
+    config.unpack,
+    initialResponse as DjangoRenderResponse,
+    initialPath
+  );
   const [overlay, setOverlay] = React.useState<{
     render(content: ReactNode): ReactNode;
     initialResponse: DjangoRenderResponse;
@@ -25,8 +32,6 @@ export function App({ config, initialResponse }: AppProps): ReactElement {
   const [overlayCloseRequested, setOverlayCloseRequested] =
     React.useState(false);
   const overlayCloseListener = React.useRef<(() => void) | null>(null);
-
-  const [render, setRender] = React.useState(0);
 
   // Toast messages
   const [messages, setMessages] = React.useState<Message[]>([]);
@@ -55,29 +60,14 @@ export function App({ config, initialResponse }: AppProps): ReactElement {
   );
 
   React.useEffect(() => {
-    // Add listener to re-render the app if a navigation event occurs
-    navigationController.addNavigationListener(() => {
-      // HACK: Update some state to force a re-render
-      setRender(render + Math.random());
-    });
-
-    // Handle initial response
-    // eslint-disable-next-line no-void
-    void navigationController
-      .handleResponse(
-        initialResponse as DjangoRenderResponse,
-        window.location.pathname
-      )
-      .then(() => {
-        // Remove the loading screen
-        const loadingScreen = document.querySelector(".django-render-load");
-        if (loadingScreen instanceof HTMLElement) {
-          loadingScreen.classList.add("django-render-load--hidden");
-          setTimeout(() => {
-            loadingScreen.remove();
-          }, 200);
-        }
-      });
+    // Remove the loading screen
+    const loadingScreen = document.querySelector(".django-render-load");
+    if (loadingScreen instanceof HTMLElement) {
+      loadingScreen.classList.add("django-render-load--hidden");
+      setTimeout(() => {
+        loadingScreen.remove();
+      }, 200);
+    }
 
     // Add listener to raise any server errors that the navigation controller encounters
     navigationController.addServerErrorListener(onServerError);

--- a/packages/core/src/index.tsx
+++ b/packages/core/src/index.tsx
@@ -152,7 +152,7 @@ export function App({ config, initialResponse }: AppProps): ReactElement {
               />
             </DirtyFormScope>
           )}
-          {!navigationController.isLoading() && (
+          {!navigationController.isLoading && (
             <Browser
               config={config}
               navigationController={navigationController}
@@ -178,7 +178,7 @@ export {
 export type { Navigation } from "./contexts";
 export { DirtyFormContext, DirtyFormMarker } from "./dirtyform";
 export type { DirtyForm } from "./dirtyform";
-export { NavigationController } from "./navigation";
+export { type NavigationController } from "./navigation";
 export type { Frame } from "./navigation";
 export type { DjangoRenderResponse as Response };
 export { Link, BuildLinkElement, buildLinkElement };

--- a/packages/core/src/navigation.ts
+++ b/packages/core/src/navigation.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import { useState } from "react";
 import { Message, djangoGet, djangoPost, DjangoRenderResponse } from "./fetch";
 
 let nextFrameId = 1;
@@ -308,4 +309,15 @@ export class NavigationController {
       (listener) => listener !== func
     );
   };
+}
+
+export function useNavigationController(
+  parent: NavigationController | null,
+  unpack: (data: Record<string, unknown>) => Record<string, unknown>
+) {
+  const [navigationController] = useState(
+    () => new NavigationController(parent, unpack)
+  );
+
+  return navigationController;
 }

--- a/packages/core/src/navigation.ts
+++ b/packages/core/src/navigation.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Message, djangoGet, djangoPost, DjangoRenderResponse } from "./fetch";
 
 let nextFrameId = 1;
@@ -13,7 +13,6 @@ export interface Frame<Props = Record<string, unknown>> {
   props: Props;
   context: Record<string, unknown>;
   serverMessages: Message[];
-  pushState: boolean;
   shouldReloadCallback?: (newPath: string, newProps: Props) => boolean;
 }
 
@@ -22,251 +21,20 @@ interface HistoryState {
   prevScrollPosition?: number;
 }
 
-export class NavigationController {
+export interface NavigationController {
   parent: NavigationController | null;
-
-  unpack: (data: Record<string, unknown>) => Record<string, unknown>;
-
-  nextFetchId = 1;
-
-  lastReceivedFetchId = 1;
-
   currentFrame: Frame;
-
-  callbacks: {
-    onNavigation?: (frame: Frame | null, newFrame: boolean) => void;
-    onOverlayClose?: () => void;
-    onServerError?: (kind: "server" | "network") => void;
-  };
-
-  constructor(
-    parent: NavigationController | null,
-    unpack: (data: Record<string, unknown>) => Record<string, unknown>,
-    initialPath: string,
-    callbacks: NavigationController["callbacks"]
-  ) {
-    this.parent = parent;
-    this.unpack = unpack;
-    this.callbacks = callbacks;
-
-    nextFrameId += 1;
-    this.currentFrame = {
-      id: nextFrameId,
-      path: initialPath,
-      title: "Loading",
-      view: "loading",
-      props: {},
-      context: {},
-      serverMessages: [],
-      pushState: false,
-    };
-  }
-
-  isLoading = () => this.currentFrame.view === "loading";
-
-  private fetch = async (
-    fetcher: () => Promise<DjangoRenderResponse>,
-    url: string,
-    pushState: boolean,
-    neverReload = false
-  ) => {
-    // Get a fetch ID
-    // We do this so that if responses come back in a different order to
-    // when the requests were sent, the older requests don't replace newer ones
-    this.nextFetchId += 1;
-    const thisFetchId = this.nextFetchId;
-
-    const response = await fetcher();
-
-    if (thisFetchId < this.lastReceivedFetchId) {
-      // A subsequent fetch was made but its response came in before this one
-      // So ignore this response
-      return;
-    }
-
-    this.lastReceivedFetchId = thisFetchId;
-
-    if (response === null) {
-      return;
-    }
-
-    await this.handleResponse(response, url, pushState, neverReload);
-  };
-
-  handleResponse = (
+  isLoading: boolean;
+  handleResponse: (
     response: DjangoRenderResponse,
     path: string,
-    pushState = true,
-    neverReload = false
-  ): Promise<void> => {
-    if (response.status === "reload") {
-      if (!this.parent) {
-        window.location.href = path;
-      } else {
-        // reload responses require reloading the entire page, but this is an overlay
-        // Escalate this response to the page's navigation controller instead
-        return this.parent.handleResponse(response, path);
-      }
-    } else if (response.status === "redirect") {
-      return this.navigate(response.path);
-    } else if (response.status === "render") {
-      // If this navigation controller is handling an overlay, make sure the response can be
-      // loaded in a overlay. Otherwise, escalate it to parent
-      if (this.parent && !response.overlay) {
-        return this.parent.handleResponse(response, path);
-      }
-
-      // Unpack props and context
-      const props = this.unpack(response.props);
-      const context = this.unpack(response.context);
-
-      // If the view is the same as the current frame, check if the frame has a shouldReloadCallback registered.
-      // If it does, call it to see if we should reload the view or just update its props
-      let reload = !neverReload;
-      if (
-        reload &&
-        response.view === this.currentFrame.view &&
-        this.currentFrame.shouldReloadCallback
-      ) {
-        reload = this.currentFrame.shouldReloadCallback(path, props);
-      }
-
-      this.pushFrame(
-        path,
-        response.title,
-        response.view,
-        props,
-        context,
-        response.messages,
-        pushState,
-        reload
-      );
-    } else if (response.status === "close-overlay") {
-      // Call overlay close callback
-      if (this.callbacks.onOverlayClose) {
-        this.callbacks.onOverlayClose();
-      }
-
-      // Push any messages
-      response.messages.forEach((message) => {
-        this.currentFrame.serverMessages.push(message);
-      });
-    } else if (response.status === "server-error") {
-      if (this.callbacks.onServerError) {
-        this.callbacks.onServerError("server");
-      }
-      return Promise.reject();
-    } else if (response.status === "network-error") {
-      if (this.callbacks.onServerError) {
-        this.callbacks.onServerError("network");
-      }
-      return Promise.reject();
-    }
-
-    return Promise.resolve();
-  };
-
-  navigate = (url: string, pushState = true): Promise<void> => {
-    let path = url;
-
-    if (!url.startsWith("/")) {
-      const urlObj = new URL(url);
-
-      if (urlObj.origin !== window.location.origin) {
-        window.location.href = url;
-        return Promise.resolve();
-      }
-
-      path = urlObj.pathname + urlObj.search;
-    }
-
-    return this.fetch(() => djangoGet(path, !!this.parent), path, pushState);
-  };
-
-  pushFrame = (
-    path: string,
-    title: string,
-    view: string,
-    props: Record<string, unknown>,
-    context: Record<string, unknown>,
-    serverMessages: Message[],
-    pushState = true,
-    reload = true
-  ) => {
-    let frameId = this.currentFrame.id;
-
-    const newFrame = view !== this.currentFrame.view || reload;
-    if (newFrame) {
-      nextFrameId += 1;
-      frameId = nextFrameId;
-    }
-
-    this.currentFrame = {
-      id: frameId,
-      path,
-      title,
-      view,
-      props,
-      context,
-      serverMessages,
-      pushState,
-    };
-
-    if (!this.parent) {
-      document.title = title;
-
-      if (this.currentFrame.pushState) {
-        let scollPositionY = 0;
-        const scrollPosition = window.scrollY;
-        const historyState = window.history?.state as HistoryState;
-        // if we're going back to previous path, return to the the previous scroll position
-        if (historyState?.prevPath === this.currentFrame.path) {
-          scollPositionY = historyState.prevScrollPosition ?? 0;
-        }
-
-        // set the previous path and scroll position in the state before pushing the new url
-        window.history.pushState(
-          {
-            prevPath: window.location.pathname,
-            prevScrollPosition: scrollPosition,
-          },
-          "",
-          this.currentFrame.path
-        );
-
-        // set the scroll position
-        window.scrollTo(0, scollPositionY);
-      }
-    }
-
-    if (this.callbacks.onNavigation) {
-      this.callbacks.onNavigation(this.currentFrame, newFrame);
-    }
-  };
-
-  replacePath = (frameId: number, path: string) => {
-    if (frameId === this.currentFrame.id) {
-      // replace-path called on current frame
-      // Change the path using replaceState
-      this.currentFrame.path = path;
-
-      if (!this.parent) {
-        // eslint-disable-next-line no-restricted-globals
-        history.replaceState({}, "", this.currentFrame.path);
-      }
-    }
-  };
-
-  submitForm = (url: string, data: FormData): Promise<void> =>
-    this.fetch(() => djangoPost(url, data, !!this.parent), url, true);
-
-  refreshProps = (): Promise<void> =>
-    this.fetch(
-      () => djangoGet(this.currentFrame.path, !!this.parent),
-      this.currentFrame.path,
-      false,
-      true
-    );
+    pushState?: boolean,
+    neverReload?: boolean
+  ) => Promise<void>;
+  navigate: (url: string, pushState?: boolean) => Promise<void>;
+  replacePath: (frameId: number, path: string) => void;
+  submitForm: (url: string, data: FormData) => Promise<void>;
+  refreshProps: () => Promise<void>;
 }
 
 export function useNavigationController(
@@ -274,35 +42,277 @@ export function useNavigationController(
   unpack: (data: Record<string, unknown>) => Record<string, unknown>,
   initialResponse: DjangoRenderResponse,
   initialPath: string,
-  callbacks: NavigationController["callbacks"] = {}
-) {
-  // Re-render if a navigation occurs
-  const [forceRender, setForceRender] = useState(0);
-  const onNavigation = useCallback(
-    (frame: Frame | null, newFrame: boolean) => {
-      // HACK: Update some state to force a re-render
-      setForceRender(forceRender + Math.random());
+  callbacks: {
+    onNavigation?: (frame: Frame | null, newFrame: boolean) => void;
+    onOverlayClose?: () => void;
+    onServerError?: (kind: "server" | "network") => void;
+  } = {}
+): NavigationController {
+  nextFrameId += 1;
+  const [currentFrame, setCurrentFrame] = useState<Frame>({
+    id: nextFrameId,
+    path: initialPath,
+    title: "Loading",
+    view: "loading",
+    props: {},
+    context: {},
+    serverMessages: [],
+  });
+
+  const pushFrame = useCallback(
+    (
+      path: string,
+      title: string,
+      view: string,
+      props: Record<string, unknown>,
+      context: Record<string, unknown>,
+      serverMessages: Message[],
+      pushState = true,
+      reload = true
+    ) => {
+      let frameId = currentFrame.id;
+
+      const newFrame = view !== currentFrame.view || reload;
+      if (newFrame) {
+        nextFrameId += 1;
+        frameId = nextFrameId;
+      }
+
+      if (!parent) {
+        document.title = title;
+
+        if (pushState) {
+          let scollPositionY = 0;
+          const scrollPosition = window.scrollY;
+          const historyState = window.history?.state as HistoryState;
+          // if we're going back to previous path, return to the the previous scroll position
+          if (historyState?.prevPath === path) {
+            scollPositionY = historyState.prevScrollPosition ?? 0;
+          }
+
+          // set the previous path and scroll position in the state before pushing the new url
+          window.history.pushState(
+            {
+              prevPath: window.location.pathname,
+              prevScrollPosition: scrollPosition,
+            },
+            "",
+            path
+          );
+
+          // set the scroll position
+          window.scrollTo(0, scollPositionY);
+        }
+      }
+
+      const nextFrame = {
+        id: frameId,
+        path,
+        title,
+        view,
+        props,
+        context,
+        serverMessages,
+      };
+      setCurrentFrame(nextFrame);
 
       if (callbacks.onNavigation) {
-        callbacks.onNavigation(frame, newFrame);
+        callbacks.onNavigation(nextFrame, newFrame);
       }
     },
-    [callbacks, forceRender]
+    [callbacks, currentFrame.id, currentFrame.view, parent]
   );
 
-  const [navigationController] = useState(
-    () =>
-      new NavigationController(parent, unpack, initialPath, {
-        ...callbacks,
-        onNavigation,
-      })
+  const [redirectTo, setRedirectTo] = useState<null | string>(null);
+
+  const handleResponse = useCallback(
+    (
+      response: DjangoRenderResponse,
+      path: string,
+      pushState = true,
+      neverReload = false
+    ): Promise<void> => {
+      if (response.status === "reload") {
+        if (!parent) {
+          window.location.href = path;
+        } else {
+          // reload responses require reloading the entire page, but this is an overlay
+          // Escalate this response to the page's navigation controller instead
+          return parent.handleResponse(response, path);
+        }
+      } else if (response.status === "redirect") {
+        // HACK: Needed to do this because we can't call navigate directly from here
+        setRedirectTo(response.path);
+        return Promise.resolve();
+      } else if (response.status === "render") {
+        // If this navigation controller is handling an overlay, make sure the response can be
+        // loaded in a overlay. Otherwise, escalate it to parent
+        if (parent && !response.overlay) {
+          return parent.handleResponse(response, path);
+        }
+
+        // Unpack props and context
+        const props = unpack(response.props);
+        const context = unpack(response.context);
+
+        // If the view is the same as the current frame, check if the frame has a shouldReloadCallback registered.
+        // If it does, call it to see if we should reload the view or just update its props
+        let reload = !neverReload;
+        if (
+          reload &&
+          response.view === currentFrame.view &&
+          currentFrame.shouldReloadCallback
+        ) {
+          reload = currentFrame.shouldReloadCallback(path, props);
+        }
+
+        pushFrame(
+          path,
+          response.title,
+          response.view,
+          props,
+          context,
+          response.messages,
+          pushState,
+          reload
+        );
+      } else if (response.status === "close-overlay") {
+        // Call overlay close callback
+        if (callbacks.onOverlayClose) {
+          callbacks.onOverlayClose();
+        }
+
+        // Push any messages
+        response.messages.forEach((message) => {
+          currentFrame.serverMessages.push(message);
+        });
+      } else if (response.status === "server-error") {
+        if (callbacks.onServerError) {
+          callbacks.onServerError("server");
+        }
+        return Promise.reject();
+      } else if (response.status === "network-error") {
+        if (callbacks.onServerError) {
+          callbacks.onServerError("network");
+        }
+        return Promise.reject();
+      }
+
+      return Promise.resolve();
+    },
+    [callbacks, currentFrame, parent, pushFrame, unpack]
+  );
+
+  const nextFetchId = useRef(1);
+  const lastReceivedFetchId = useRef(1);
+
+  const fetch = useCallback(
+    async (
+      fetcher: () => Promise<DjangoRenderResponse>,
+      url: string,
+      pushState: boolean,
+      neverReload = false
+    ) => {
+      // Get a fetch ID
+      // We do this so that if responses come back in a different order to
+      // when the requests were sent, the older requests don't replace newer ones
+      nextFetchId.current += 1;
+      const thisFetchId = nextFetchId.current;
+
+      const response = await fetcher();
+
+      if (thisFetchId < lastReceivedFetchId.current) {
+        // A subsequent fetch was made but its response came in before this one
+        // So ignore this response
+        return;
+      }
+
+      lastReceivedFetchId.current = thisFetchId;
+
+      if (response === null) {
+        return;
+      }
+
+      await handleResponse(response, url, pushState, neverReload);
+    },
+    [handleResponse]
+  );
+
+  const navigate = useCallback(
+    (url: string, pushState = true): Promise<void> => {
+      let path = url;
+
+      if (!url.startsWith("/")) {
+        const urlObj = new URL(url);
+
+        if (urlObj.origin !== window.location.origin) {
+          window.location.href = url;
+          return Promise.resolve();
+        }
+
+        path = urlObj.pathname + urlObj.search;
+      }
+
+      return fetch(() => djangoGet(path, !!parent), path, pushState);
+    },
+    [fetch, parent]
+  );
+
+  const replacePath = useCallback(
+    (frameId: number, path: string) => {
+      if (frameId === currentFrame.id) {
+        // replace-path called on current frame
+        // Change the path using replaceState
+        currentFrame.path = path;
+
+        if (!parent) {
+          // eslint-disable-next-line no-restricted-globals
+          history.replaceState({}, "", currentFrame.path);
+        }
+      }
+    },
+    [currentFrame, parent]
+  );
+
+  const submitForm = useCallback(
+    (url: string, data: FormData): Promise<void> =>
+      fetch(() => djangoPost(url, data, !!parent), url, true),
+    [fetch, parent]
+  );
+
+  const refreshProps = useCallback(
+    (): Promise<void> =>
+      fetch(
+        () => djangoGet(currentFrame.path, !!parent),
+        currentFrame.path,
+        false,
+        true
+      ),
+    [currentFrame.path, fetch, parent]
   );
 
   useEffect(() => {
     // Load initial response
     // eslint-disable-next-line no-void
-    void navigationController.handleResponse(initialResponse, initialPath);
+    void handleResponse(initialResponse, initialPath);
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  return navigationController;
+  useEffect(() => {
+    if (redirectTo) {
+      setRedirectTo(null);
+      // eslint-disable-next-line no-void
+      void navigate(redirectTo);
+    }
+  }, [navigate, redirectTo]);
+
+  return {
+    parent,
+    currentFrame,
+    isLoading: currentFrame.view === "loading",
+    handleResponse,
+    navigate,
+    replacePath,
+    submitForm,
+    refreshProps,
+  };
 }

--- a/packages/core/src/navigation.ts
+++ b/packages/core/src/navigation.ts
@@ -51,7 +51,10 @@ export class NavigationController {
     nextFrameId += 1;
     this.currentFrame = {
       id: nextFrameId,
-      path: window.location.pathname,
+      path:
+        window.location.pathname +
+        window.location.search +
+        window.location.hash,
       title: "Loading",
       view: "loading",
       props: {},
@@ -253,12 +256,13 @@ export class NavigationController {
   submitForm = (url: string, data: FormData): Promise<void> =>
     this.fetch(() => djangoPost(url, data, !!this.parent), url, true);
 
-  refreshProps = (): Promise<void> => {
-    const url =
-      window.location.pathname + window.location.search + window.location.hash;
-
-    return this.fetch(() => djangoGet(url, !!this.parent), url, false, true);
-  };
+  refreshProps = (): Promise<void> =>
+    this.fetch(
+      () => djangoGet(this.currentFrame.path, !!this.parent),
+      this.currentFrame.path,
+      false,
+      true
+    );
 
   // Called by a child NavigationController when it cannot handle a response.
   // For example, say this NavigationController controls the main window and there's a

--- a/packages/core/src/navigation.ts
+++ b/packages/core/src/navigation.ts
@@ -105,7 +105,7 @@ export class NavigationController {
       } else {
         // reload responses require reloading the entire page, but this is an overlay
         // Escalate this response to the page's navigation controller instead
-        return this.parent.escalate(path, response);
+        return this.parent.handleResponse(response, path);
       }
     } else if (response.status === "redirect") {
       return this.navigate(response.path);
@@ -113,7 +113,7 @@ export class NavigationController {
       // If this navigation controller is handling an overlay, make sure the response can be
       // loaded in a overlay. Otherwise, escalate it to parent
       if (this.parent && !response.overlay) {
-        return this.parent.escalate(path, response);
+        return this.parent.handleResponse(response, path);
       }
 
       // Unpack props and context
@@ -267,17 +267,6 @@ export class NavigationController {
       false,
       true
     );
-
-  // Called by a child NavigationController when it cannot handle a response.
-  // For example, say this NavigationController controls the main window and there's a
-  // overlay open that has a different NavigationController. If the user clicks a link
-  // that needs to navigate the whole page somewhere else, that response is escalated
-  // from the overlay NavigationController to the main window NavigationController using
-  // this method.
-  private escalate = (
-    url: string,
-    response: DjangoRenderResponse
-  ): Promise<void> => this.handleResponse(response, url);
 }
 
 export function useNavigationController(

--- a/packages/storybook/src/index.tsx
+++ b/packages/storybook/src/index.tsx
@@ -66,12 +66,6 @@ export function OverrideLinks({
       props: {},
       context: {},
       navigate,
-      pushFrame: () => {
-        // eslint-disable-next-line no-console
-        console.error("pushFrame() cannot be used in storybooks");
-
-        return Promise.resolve();
-      },
       replacePath: () => {},
       submitForm: navigate,
       openOverlay: navigate,


### PR DESCRIPTION
Currently, navigation controllers are classes that contain attributes that aren't known to React. When these attributes change, the controller calls a "navigation listener" to force a a React-managed state value to change that triggers the re-render.

This makes it difficult for us to create effects that depend on attributes on navigation controllers. I'm looking to solve https://github.com/kaedroho/django-render/issues/7 but need a reliable way to know when the `currentFrame` attribute changes.