### PR TITLE
Fix messages not clearing on form submit

### DIFF
--- a/packages/core/src/index.tsx
+++ b/packages/core/src/index.tsx
@@ -75,11 +75,11 @@ export function App({ config, initialResponse }: AppProps): ReactElement {
     // replacePath() and refreshProps() will update the existing one.
     // We don't want to delete messages for the latter two.
     if (newFrame) {
-      setMessages([]);
+      setMessages(newMessages);
+    } else {
+      // Push any new messages from server
+      newMessages.forEach(pushMessage);
     }
-
-    // Push any new messages from server
-    newMessages.forEach(pushMessage);
   };
 
   const initialPath =


### PR DESCRIPTION
For some reason, on form submit, the `setMessages([])` call wasn't making a change before the subsequent `pushMessage()` call.

This meant that the cleared out messages were immediately put back as `pushMessage()` itself calls `setMessages` with existing messages concatenated to the new one.